### PR TITLE
Fix: The filename of a maven artifact should contain the classifier on the correct position

### DIFF
--- a/mvn-artifact-filename/README.md
+++ b/mvn-artifact-filename/README.md
@@ -39,11 +39,11 @@ artifact = {
   groupId: 'org.apache.commons',
   artifactId: 'commons-lang3',
   extension: 'war',
-  classifier: 'test',
+  classifier: 'tests',
   version: '3.4'
 }
 createFilename(artifact)
-//=> "commons-lang3-test-3.4.war"
+//=> "commons-lang3-3.4-tests.war"
 ```
 
 ## Contributing

--- a/mvn-artifact-filename/src/filename.ts
+++ b/mvn-artifact-filename/src/filename.ts
@@ -13,8 +13,8 @@ export default function filename (artifact: Artifact) {
     if (artifact.classifier) {
         return util.format("%s-%s-%s.%s",
                            artifact.artifactId,
-                           artifact.classifier,
                            artifact.version,
+                           artifact.classifier,
                            extension);
     };
     return util.format("%s-%s.%s",

--- a/mvn-artifact-filename/test/test.js
+++ b/mvn-artifact-filename/test/test.js
@@ -12,7 +12,7 @@ describe('mvn-artifact-url', function () {
     }
     expect(filename(artifact)).to.equal('commons-lang3-3.4.jar')
   })
-  it('should give war filename', function () {
+  it('should yield the war filename', function () {
     let artifact = {
       groupId: 'org.apache.commons',
       artifactId: 'commons-lang3',
@@ -21,14 +21,14 @@ describe('mvn-artifact-url', function () {
     }
     expect(filename(artifact)).to.equal('commons-lang3-3.4.war')
   })
-  it('should give war filename with classifier', function () {
+  it('should yield the filename with a classifier', function () {
     let artifact = {
-      groupId: 'org.apache.commons',
-      artifactId: 'commons-lang3',
-      extension: 'war',
+      groupId: 'org.apache.openejb',
+      artifactId: 'openejb-itests-webapp',
+      extension: 'jar',
       classifier: 'test',
-      version: '3.4'
+      version: '3.0-beta-1'
     }
-    expect(filename(artifact)).to.equal('commons-lang3-test-3.4.war')
+    expect(filename(artifact)).to.equal('openejb-itests-webapp-3.0-beta-1-test.jar')
   })
 })

--- a/mvn-artifact-url/.gitignore
+++ b/mvn-artifact-url/.gitignore
@@ -1,1 +1,3 @@
 /built
+
+node_modules

--- a/mvn-artifact-url/test/test.js
+++ b/mvn-artifact-url/test/test.js
@@ -2,20 +2,54 @@
 import { expect } from 'chai'
 import url from '../'
 
-let artifact = {
-  groupId: 'org.apache.commons',
-  artifactId: 'commons-lang3',
-  version: '3.4'
-}
-
 describe('mvn-artifact-url', function () {
-  it('should contain artifact path', function () {
-    expect(url(artifact, '.')).to.have.string('org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar')
+
+  describe('of a regular artifact', function () {
+
+    let artifact = {
+      groupId: 'org.apache.commons',
+      artifactId: 'commons-lang3',
+      version: '3.4'
+    }
+
+    it('should contain a path to the artifact', function () {
+      expect(url(artifact, '.')).to.contain('org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar')
+    })
+
+    it('should contain the default base url', function () {
+      expect(url(artifact)).to.contain('https://repo1.maven.org/maven2/')
+    })
+
+    it('can contain a base url other than the default', function () {
+      expect(url(artifact, 'http://localhost/')).to.contain('http://localhost/')
+    })
   })
-  it('should contain default url', function () {
-    expect(url(artifact)).to.have.string('https://repo1.maven.org/maven2/')
+
+  describe('of an artifact with a classifier specified', function () {
+
+    let artifact = {
+      groupId: 'io.joynr.java.android',
+      artifactId: 'joynr-android',
+      version: '0.19.5',
+      classifier: 'all'
+    }
+
+    it('should contain a path to the artifact', function () {
+      expect(url(artifact, '.')).to.contain('io/joynr/java/android/joynr-android/0.19.5/joynr-android-0.19.5-all.jar')
+    })
   })
-  it('should use another basepath than default', function () {
-    expect(url(artifact, 'http://localhost/')).to.have.string('http://localhost/')
+
+  describe('of an artifact with packaging specified', function () {
+
+    let artifact = {
+      groupId: 'org.apache.commons',
+      artifactId: 'commons-lang3',
+      version: '3.4',
+      extension: 'pom'
+    }
+
+    it('should contain a path to the artifact', function () {
+      expect(url(artifact, '.')).to.contain('org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.pom')
+    })
   })
 })


### PR DESCRIPTION
Given an artifact such that:
- groupId: org.apache.commons
- artifactId: commons-lang3
- classifier: tests
- version: 3.4

the correct filename should be `commons-lang3-3.4-tests.jar` rather than `commons-lang3-tests-3.4.jar`.

This pull requests fixes this issue.