### PR TITLE
Fix: Replaced the es6-promise shim with standard node.js promises

### DIFF
--- a/mvn-artifact-download/package.json
+++ b/mvn-artifact-download/package.json
@@ -47,7 +47,6 @@
     "mvn-artifact-name-parser": "~1.0.0",
     "mvn-artifact-filename": "~1.0.0",
     "mvn-artifact-url": "~1.0.0",
-    "es6-promise": "^3.0.2",
     "request": "^2.67.0"
   }
 }

--- a/mvn-artifact-download/src/artifact-download.ts
+++ b/mvn-artifact-download/src/artifact-download.ts
@@ -1,6 +1,5 @@
 import * as fs from "fs";
 import * as path from "path";
-import { Promise } from "es6-promise";
 import * as request from "request";
 import parseName from "mvn-artifact-name-parser";
 import filename from "mvn-artifact-filename";

--- a/mvn-artifact-download/tsconfig.json
+++ b/mvn-artifact-download/tsconfig.json
@@ -9,6 +9,10 @@
         "sourceMap": true
     },
     "package": "package.json",
+    "files": [
+        "src/artifact-download.ts",
+        "typings/index.d.ts"
+    ],
     "exclude": [
         "node_modules",
         "built"

--- a/mvn-artifact-download/typings.json
+++ b/mvn-artifact-download/typings.json
@@ -1,7 +1,5 @@
 {
-  "devDependencies": {
-    "es6-promise": "registry:npm/es6-promise#3.0.0+20160723033700",
-    "form-data": "registry:npm/form-data#1.0.0+20160723033700",
+  "dependencies": {
     "request": "registry:npm/request#2.69.0+20160428223725"
   },
   "globalDevDependencies": {
@@ -9,7 +7,10 @@
     "chai-as-promised": "registry:dt/chai-as-promised#0.0.0+20160423070304",
     "mock-fs": "registry:dt/mock-fs#3.6.0+20160317120654",
     "nock": "registry:dt/nock#0.54.0+20160613160405",
-    "node": "registry:dt/node#6.0.0+20160805072842",
+    "node": "registry:dt/node#6.0.0+20160805072842"
+  },
+  "globalDependencies": {
+    "core-js": "registry:dt/core-js#0.0.0+20160725163759",
     "promises-a-plus": "registry:dt/promises-a-plus#0.0.0+20160317120654"
   }
 }


### PR DESCRIPTION
Looks like the `es6-promise` module causes conflicts with the standard node.js promises if both are used together on the same project.

Since `mvn-artifact-download` will only ever be used on node.js (which supports promises), there's no need for the shim (and the conflicts ;-) ). This PR removes it.

Oh, I've also removed the typings for the `form-data` as the module that the typings support is not used by this project.