### PR TITLE
Add support for timestamped snapshot versions

### DIFF
--- a/mvn-artifact-download/test/test.js
+++ b/mvn-artifact-download/test/test.js
@@ -49,4 +49,19 @@ describe('mvn-artifact-url', function () {
     let dl = download('org.apache.commons:commons-lang3:3.4')
     expect(dl).to.eventually.be.rejected.and.notify(done)
   })
+  it.only('should download latest snapshot version of artifact', function (done) {
+    let metadataXml = '<metadata><groupId>org.apache.commons</groupId><artifactId>commons-lang3</artifactId><version>3.4-SNAPSHOT</version><versioning><snapshot><timestamp>1</timestamp><buildNumber>23</buildNumber></snapshot><lastUpdated>20120607154257</lastUpdated><snapshotVersions><snapshotVersion><extension>jar</extension><value>1.0-20120607.154257-1339076577</value><updated>20120607154257</updated></snapshotVersion></snapshotVersions></versioning></metadata>';
+    nock('https://repo1.maven.org/maven2/')
+    .get('/org/apache/commons/commons-lang3/3.4-SNAPSHOT/maven-metadata.xml')
+    .reply(200, metadataXml)
+
+    nock('https://repo1.maven.org/maven2/')
+    .get('/org/apache/commons/commons-lang3/3.4-SNAPSHOT/commons-lang3-3.4-1-23.jar')
+    .reply(200, metadataXml)
+
+    mockFs()
+    let dl = download('org.apache.commons:commons-lang3:3.4-SNAPSHOT')
+
+    expect(dl).to.eventually.equal(cwd + '/commons-lang3-3.4-1-23.jar').and.notify(done)
+  })
 })

--- a/mvn-artifact-filename/src/filename.ts
+++ b/mvn-artifact-filename/src/filename.ts
@@ -6,19 +6,26 @@ export interface Artifact {
     version: string;
     extension?: string;
     classifier?: string;
+    isSnapShot?: boolean;
+    snapShotVersion?: string;
 }
 
+const getVersion = function(artifact: Artifact): string {
+    return artifact.version + (artifact.isSnapShot ? "-" + artifact.snapShotVersion : "");
+};
 export default function filename (artifact: Artifact) {
     const extension = artifact.extension || "jar";
+    let version = getVersion(artifact);
+
     if (artifact.classifier) {
         return util.format("%s-%s-%s.%s",
                            artifact.artifactId,
-                           artifact.version,
+                           version,
                            artifact.classifier,
                            extension);
     };
     return util.format("%s-%s.%s",
                        artifact.artifactId,
-                       artifact.version,
+                       version,
                        extension);
 }

--- a/mvn-artifact-filename/test/test.js
+++ b/mvn-artifact-filename/test/test.js
@@ -31,4 +31,14 @@ describe('mvn-artifact-url', function () {
     }
     expect(filename(artifact)).to.equal('openejb-itests-webapp-3.0-beta-1-test.jar')
   })
+  it('should yield the filename for the snapshot version', function () {
+    let artifact = {
+      groupId: 'org.apache.openejb',
+      artifactId: 'openejb-itests-webapp',
+      version: '3.0',
+      isSnapShot: true,
+      snapShotVersion: '123'
+    }
+    expect(filename(artifact)).to.equal('openejb-itests-webapp-3.0-123.jar')
+  })
 })

--- a/mvn-artifact-name-parser/src/parse.ts
+++ b/mvn-artifact-name-parser/src/parse.ts
@@ -4,6 +4,8 @@ export interface Artifact {
     version: string;
     extension?: string;
     classifier?: string;
+    isSnapShot?: boolean;
+    snapShotVersion?: string;
 }
 export default function parseArtifact (name: string): Artifact {
     const parts = name.split(":");
@@ -18,6 +20,10 @@ export default function parseArtifact (name: string): Artifact {
         }
         if (parts.length > 4) {
             artifact.classifier = parts[3];
+        }
+        if(artifact.version.endsWith("-SNAPSHOT")){
+            artifact.isSnapShot = true;
+            artifact.version = artifact.version.substr(0, artifact.version.indexOf("-SNAPSHOT"));
         }
         return artifact;
     }

--- a/mvn-artifact-name-parser/test/test.js
+++ b/mvn-artifact-name-parser/test/test.js
@@ -17,4 +17,11 @@ describe('artifact-name-parser', function () {
     expect(artifact.version).to.equal('3.4')
     expect(artifact.extension).to.equal('war')
   })
+  it('should parse artifact with SNAPSHOT version', function () {
+    var artifact = parse('org.apache.commons:commons-lang3:3.4-SNAPSHOT')
+    expect(artifact.groupId).to.equal('org.apache.commons')
+    expect(artifact.artifactId).to.equal('commons-lang3')
+    expect(artifact.version).to.equal('3.4')
+    expect(artifact.isSnapShot).to.equal(true)
+  })
 })

--- a/mvn-artifact-name-parser/tsconfig.json
+++ b/mvn-artifact-name-parser/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "declaration": true,
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "noImplicitAny": true,
         "outDir": "built",
         "rootDir": "src",

--- a/mvn-artifact-url/package.json
+++ b/mvn-artifact-url/package.json
@@ -27,14 +27,19 @@
   },
   "homepage": "https://github.com/laat/mvn-dl#readme",
   "dependencies": {
-    "mvn-artifact-filename": "^1.0.0"
+    "mvn-artifact-filename": "^1.0.0",
+    "xml2js" : "^0.4.17",
+    "request": "^2.81.0"
   },
   "devDependencies": {
     "babel-cli": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
     "chai": "*",
+    "chai-as-promised": "^5.1.0",
     "mocha": "*",
+    "mock-fs": "^3.5.0",
+    "nock": "^8.0.0",
     "onchange": "^2.2.0",
     "readme-assert": "^2.1.2",
     "tslint": "^3.7.1",

--- a/mvn-artifact-url/src/artifact-url.ts
+++ b/mvn-artifact-url/src/artifact-url.ts
@@ -1,6 +1,8 @@
 import * as path from "path";
 import * as util from "util";
 import filename from "mvn-artifact-filename";
+var parseString = require("xml2js").parseString;
+var request = require("request");
 
 export interface Artifact {
     groupId: string;
@@ -8,12 +10,14 @@ export interface Artifact {
     version: string;
     extension?: string;
     classifier?: string;
+    isSnapShot?: boolean;
+    snapShotVersion?: string;
 }
 
 const groupPath = function (artifact: Artifact): string {
   return [artifact.groupId.replace(/\./g, "/"),
     artifact.artifactId,
-    artifact.version
+    artifact.version + (artifact.isSnapShot ? "-SNAPSHOT" : "")
   ].join("/");
 };
 
@@ -21,7 +25,41 @@ const artifactPath = function (artifact: Artifact): string {
   return path.join(groupPath(artifact), filename(artifact));
 };
 
+const latestSnapShotVersion = function(artifact: Artifact, basepath: string){
+  return new Promise(function(resolve: any, reject: any){
+    let metadataUrl = basepath + groupPath(artifact) + "/maven-metadata.xml";
+    request(metadataUrl, function(error: any, response: any, body: any){
+      if(response.statusCode != 200){
+        reject(response.statusCode);
+      } else {
+        parseString(body, function(err: any, result: any){
+          if(err){
+            reject(err);
+          } else {
+            let snapshot = result.metadata.versioning[0].snapshot[0];
+            let version = snapshot.timestamp[0] + "-" + snapshot.buildNumber[0];
+            resolve(version);
+          }
+        });
+      }
+    });
+  });
+};
+
 export default function artifactUrl (artifact: Artifact, basepath: string) {
-  let prefix = basepath || "https://repo1.maven.org/maven2/";
-  return prefix + artifactPath(artifact);
+  return new Promise(function(resolve: any, reject: any){
+    let prefix = basepath || "https://repo1.maven.org/maven2/";
+    if(artifact.isSnapShot){
+      latestSnapShotVersion(artifact, prefix).then(function(version: string){
+        artifact.snapShotVersion = version;
+        let url = prefix + artifactPath(artifact);
+        resolve(url);
+      }, function(err: any){
+        reject(err);
+      });
+    } else {
+      let url = prefix + artifactPath(artifact);
+      resolve(url);
+    }
+  });
 }

--- a/mvn-artifact-url/test/test.js
+++ b/mvn-artifact-url/test/test.js
@@ -1,55 +1,84 @@
 /* eslint-env mocha */
-import { expect } from 'chai'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import nock from 'nock'
 import url from '../'
+const expect = chai.expect
+chai.use(chaiAsPromised)
 
 describe('mvn-artifact-url', function () {
 
   describe('of a regular artifact', function () {
 
-    let artifact = {
-      groupId: 'org.apache.commons',
-      artifactId: 'commons-lang3',
-      version: '3.4'
-    }
+let artifact = {
+  groupId: 'org.apache.commons',
+  artifactId: 'commons-lang3',
+  version: '3.4'
+}
 
-    it('should contain a path to the artifact', function () {
-      expect(url(artifact, '.')).to.contain('org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar')
-    })
+it('should contain a path to the artifact', function (done) {
+  let urlPromise = url(artifact, '.');
+  expect(urlPromise).to.eventually.contain('org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar').and.notify(done);
+})
 
-    it('should contain the default base url', function () {
-      expect(url(artifact)).to.contain('https://repo1.maven.org/maven2/')
-    })
+it('should contain the default base url', function (done) {
+  let urlPromise = url(artifact);
+  expect(urlPromise).to.eventually.contain('https://repo1.maven.org/maven2/').and.notify(done);
+})
 
-    it('can contain a base url other than the default', function () {
-      expect(url(artifact, 'http://localhost/')).to.contain('http://localhost/')
-    })
+it('can contain a base url other than the default', function (done) {
+  let urlPromise = url(artifact, 'http://localhost/')
+  expect(urlPromise).to.eventually.contain('http://localhost/').and.notify(done)
+})
   })
 
   describe('of an artifact with a classifier specified', function () {
 
-    let artifact = {
-      groupId: 'io.joynr.java.android',
-      artifactId: 'joynr-android',
-      version: '0.19.5',
-      classifier: 'all'
-    }
+let artifact = {
+  groupId: 'io.joynr.java.android',
+  artifactId: 'joynr-android',
+  version: '0.19.5',
+  classifier: 'all'
+}
 
-    it('should contain a path to the artifact', function () {
-      expect(url(artifact, '.')).to.contain('io/joynr/java/android/joynr-android/0.19.5/joynr-android-0.19.5-all.jar')
-    })
+it('should contain a path to the artifact', function (done) {
+  let urlPromise = url(artifact, '.');
+  expect(urlPromise).to.eventually.contain('io/joynr/java/android/joynr-android/0.19.5/joynr-android-0.19.5-all.jar').and.notify(done)
+})
   })
 
   describe('of an artifact with packaging specified', function () {
+
+let artifact = {
+  groupId: 'org.apache.commons',
+  artifactId: 'commons-lang3',
+  version: '3.4',
+  extension: 'pom'
+}
+
+it('should contain a path to the artifact', function (done) {
+  let urlPromise = url(artifact, '.');
+  expect(urlPromise).to.eventually.contain('org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.pom').and.notify(done);
+})
+  })
+
+  describe.only('of an artifact with snapshot version', function () {
 
     let artifact = {
       groupId: 'org.apache.commons',
       artifactId: 'commons-lang3',
       version: '3.4',
-      extension: 'pom'
+      isSnapShot: true
     }
 
-    it('should contain a path to the artifact', function () {
-      expect(url(artifact, '.')).to.contain('org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.pom')
+    let metadataXml = '<metadata><groupId>org.apache.commons</groupId><artifactId>commons-lang3</artifactId><version>3.4-SNAPSHOT</version><versioning><snapshot><timestamp>1</timestamp><buildNumber>23</buildNumber></snapshot><lastUpdated>20120607154257</lastUpdated><snapshotVersions><snapshotVersion><extension>jar</extension><value>1.0-20120607.154257-1339076577</value><updated>20120607154257</updated></snapshotVersion></snapshotVersions></versioning></metadata>';
+    it('should contain a path to the artifact', function (done) {
+      nock('https://repo1.maven.org/maven2/')
+      .get('/org/apache/commons/commons-lang3/3.4-SNAPSHOT/maven-metadata.xml')
+      .reply(200, metadataXml)
+
+      let urlPromise = url(artifact);
+      expect(urlPromise).to.eventually.contain('org/apache/commons/commons-lang3/3.4-SNAPSHOT/commons-lang3-3.4-1-23.jar').and.notify(done);
     })
-  })
+  });
 })

--- a/mvn-artifact-url/tsconfig.json
+++ b/mvn-artifact-url/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "declaration": true,
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "noImplicitAny": true,
         "outDir": "built",
         "rootDir": "src",


### PR DESCRIPTION
Example: com.expample:example:1.0-SNAPSHOT will have jars under /com/example/example/1.0-SNAPSHOT but the jar names will be 1.0-20170411.125827-1.jar