### PR TITLE
makes use of artifact.snapShotVersion

### DIFF
--- a/packages/mvn-artifact-url/src/artifact-url.ts
+++ b/packages/mvn-artifact-url/src/artifact-url.ts
@@ -47,7 +47,7 @@ export default (async function artifactUrl(
   const prefix = basePath || 'https://repo1.maven.org/maven2/';
   if (artifact.isSnapShot) {
     const snapShotVersion = await latestSnapShotVersion(artifact, prefix);
-    return prefix + artifactPath({ ...artifact, snapShotVersion });
+    return prefix + artifactPath({ snapShotVersion, ...artifact });
   } else {
     return prefix + artifactPath(artifact);
   }

--- a/packages/mvn-artifact-url/test/test.js
+++ b/packages/mvn-artifact-url/test/test.js
@@ -99,4 +99,31 @@ describe('mvn-artifact-url', function() {
         .and.notify(done);
     });
   });
+
+  describe('of an artifact with snapShotVersion defined in the Artifact object', function() {
+    let artifact = {
+      groupId: 'org.apache.commons',
+      artifactId: 'commons-lang3',
+      version: '3.4',
+      isSnapShot: true,
+      snapShotVersion: '1.2.3.4',
+    };
+
+    let metadataXml =
+      '<metadata><groupId>org.apache.commons</groupId><artifactId>commons-lang3</artifactId><version>3.4-SNAPSHOT</version><versioning><snapshot><timestamp>1</timestamp><buildNumber>23</buildNumber></snapshot><lastUpdated>20120607154257</lastUpdated><snapshotVersions><snapshotVersion><extension>jar</extension><value>1.0-20120607.154257-1339076577</value><updated>20120607154257</updated></snapshotVersion></snapshotVersions></versioning></metadata>';
+    it('should contain a path to the artifact', function(done) {
+      nock('https://repo1.maven.org/maven2/')
+        .get(
+          '/org/apache/commons/commons-lang3/3.4-SNAPSHOT/maven-metadata.xml'
+        )
+        .reply(200, metadataXml);
+
+      let urlPromise = url(artifact);
+      expect(urlPromise)
+        .to.eventually.contain(
+          'org/apache/commons/commons-lang3/3.4-SNAPSHOT/commons-lang3-3.4-1.2.3.4.jar'
+        )
+        .and.notify(done);
+    });
+  });
 });


### PR DESCRIPTION
`artifact.snapShotVersion` takes precedence over the `lastestSnapShotVersion`