### PR TITLE
Forward fetchOptions to snapshot metadata fetch (fixes #54)

### DIFF
--- a/packages/mvn-artifact-download/src/artifact-download.ts
+++ b/packages/mvn-artifact-download/src/artifact-download.ts
@@ -3,7 +3,7 @@ import { Agent } from 'http';
 import getFilename from 'mvn-artifact-filename';
 import parseName from 'mvn-artifact-name-parser';
 import artifactUrl from 'mvn-artifact-url';
-import fetch from 'node-fetch';
+import fetch, { HeadersInit } from 'node-fetch';
 import path from 'path';
 
 export interface Artifact {
@@ -26,6 +26,10 @@ export interface FetchOptions {
    * @default 0
    */
   timeout?: number;
+  /**
+   * request headers, e.g. `{ Authorization: "Bearer ..." }` for private registries
+   */
+  headers?: HeadersInit;
 }
 
 function pipeToFile(body: NodeJS.ReadableStream, destFile: string) {

--- a/packages/mvn-artifact-url/src/artifact-url.ts
+++ b/packages/mvn-artifact-url/src/artifact-url.ts
@@ -1,6 +1,6 @@
 import { Agent } from 'http';
 import filename from 'mvn-artifact-filename';
-import fetch from 'node-fetch';
+import fetch, { HeadersInit } from 'node-fetch';
 import parseXmlString from './parseXmlString';
 
 export interface Artifact {
@@ -24,6 +24,10 @@ export interface FetchOptions {
    * @default 0
    */
   timeout?: number;
+  /**
+   * request headers, e.g. `{ Authorization: "Bearer ..." }` for private registries
+   */
+  headers?: HeadersInit;
 }
 
 function groupPath(artifact: Artifact): string {
@@ -44,10 +48,7 @@ async function latestSnapShotVersion(
   fetchOptions: FetchOptions = {}
 ) {
   const metadataUrl = basepath + groupPath(artifact) + '/maven-metadata.xml';
-  const response = await fetch(metadataUrl, {
-    agent: fetchOptions.agent,
-    timeout: fetchOptions.timeout,
-  });
+  const response = await fetch(metadataUrl, fetchOptions);
   if (response.status !== 200) {
     throw new Error(
       `Unable to fetch ${metadataUrl}. Status ${response.status}`

--- a/packages/mvn-artifact-url/test/test.js
+++ b/packages/mvn-artifact-url/test/test.js
@@ -100,6 +100,37 @@ describe('mvn-artifact-url', function () {
     });
   });
 
+  describe('of a snapshot artifact fetched from a private registry', function () {
+    let artifact = {
+      groupId: 'org.apache.commons',
+      artifactId: 'commons-lang3',
+      version: '3.4',
+      isSnapShot: true,
+    };
+
+    let metadataXml =
+      '<metadata><groupId>org.apache.commons</groupId><artifactId>commons-lang3</artifactId><version>3.4-SNAPSHOT</version><versioning><snapshot><timestamp>1</timestamp><buildNumber>23</buildNumber></snapshot><lastUpdated>20120607154257</lastUpdated><snapshotVersions><snapshotVersion><extension>jar</extension><value>1.0-20120607.154257-1339076577</value><updated>20120607154257</updated></snapshotVersion></snapshotVersions></versioning></metadata>';
+
+    it('should forward fetchOptions.headers to the metadata request', function (done) {
+      nock('https://private.example.com/maven2/', {
+        reqheaders: { authorization: 'Bearer secret-token' },
+      })
+        .get(
+          '/org/apache/commons/commons-lang3/3.4-SNAPSHOT/maven-metadata.xml'
+        )
+        .reply(200, metadataXml);
+
+      let urlPromise = url(artifact, 'https://private.example.com/maven2/', {
+        headers: { Authorization: 'Bearer secret-token' },
+      });
+      expect(urlPromise)
+        .to.eventually.contain(
+          'org/apache/commons/commons-lang3/3.4-SNAPSHOT/commons-lang3-3.4-1-23.jar'
+        )
+        .and.notify(done);
+    });
+  });
+
   describe('of an artifact with snapShotVersion defined in the Artifact object', function () {
     let artifact = {
       groupId: 'org.apache.commons',


### PR DESCRIPTION
## Summary
- `latestSnapShotVersion` in `mvn-artifact-url` was destructuring `fetchOptions` and only forwarding `agent` and `timeout`, silently dropping any custom headers. This made it impossible to authenticate against private registries (GitHub Packages, Artifactory, etc.) when resolving snapshot artifacts — exactly the bug reported in #54.
- Pass `fetchOptions` through to `node-fetch` unchanged so callers can supply arbitrary request options (the matching `fetch` call in `mvn-artifact-download` already did this).
- Add a typed `headers?: HeadersInit` field to `FetchOptions` in both `mvn-artifact-url` and `mvn-artifact-download` so TypeScript consumers can pass `Authorization` headers without casting.

## Test plan
- [x] `npm test` in `packages/mvn-artifact-url` — added a new test that uses `nock`'s `reqheaders` matcher to verify a custom `Authorization` header is forwarded to the snapshot `maven-metadata.xml` request.
- [x] `npm test` in `packages/mvn-artifact-download` — existing tests still pass.

Closes #54