### PR TITLE
Complete the native fetch migration

### DIFF
--- a/packages/mvn-artifact-download/readme.md
+++ b/packages/mvn-artifact-download/readme.md
@@ -35,8 +35,13 @@ download(
   'org.apache.commons:commons-lang3:3.4',
   null,
   'http://alternative.repo',
-  { timout: 1000 } // with optional timeout
+  { signal: AbortSignal.timeout(1000) } // with optional timeout
 );
+// Promise that resolves to destination filename
+
+download('org.apache.commons:commons-lang3:3.4', null, 'http://private.repo', {
+  headers: { Authorization: 'Bearer my-token' }, // for private registries
+});
 // Promise that resolves to destination filename
 ```
 
@@ -61,10 +66,12 @@ Type: `string`
 
 #### fetchOptions
 
-An optional object containing
+Type: [`RequestInit`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit)
 
-Attribute: **timeout** `number` req/res timeout in ms
-Attribute: **agent** `http.Agent` allows custom proxy, certificate etc.
+Optional options passed to the built-in `fetch`, for example
+
+Attribute: **headers** `HeadersInit` request headers, e.g. `{ Authorization: 'Bearer ...' }` for private registries
+Attribute: **signal** `AbortSignal` cancellation/timeout, e.g. `AbortSignal.timeout(1000)`
 
 ## License
 

--- a/packages/mvn-artifact-download/src/artifact-download.ts
+++ b/packages/mvn-artifact-download/src/artifact-download.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
+import type { ReadableStream } from 'node:stream/web';
 import path from 'node:path';
 import getFilename from 'mvn-artifact-filename';
 import parseName from 'mvn-artifact-name-parser';
@@ -15,7 +16,7 @@ export interface Artifact {
   isSnapShot?: boolean;
   snapShotVersion?: string;
 }
-export interface FetchOptions {
+export interface FetchOptions extends RequestInit {
   /**
    * request headers, e.g. `{ Authorization: "Bearer ..." }` for private registries
    */
@@ -51,7 +52,7 @@ export default async function download(
     throw new Error(`Empty response body for ${url}`);
   }
   await pipeline(
-    Readable.fromWeb(response.body as any),
+    Readable.fromWeb(response.body as ReadableStream<Uint8Array>),
     fs.createWriteStream(destFile)
   );
   return destFile;

--- a/packages/mvn-artifact-download/test/artifact-download.test.js
+++ b/packages/mvn-artifact-download/test/artifact-download.test.js
@@ -91,6 +91,33 @@ test('should download artifact from custom repository', async () => {
   assert.equal(result, path.join(tmpDir, 'commons-lang3-3.4.jar'));
 });
 
+test('should forward fetchOptions.headers to the registry', async () => {
+  nock('https://private.example.com/maven2/', {
+    reqheaders: { authorization: 'Bearer secret-token' },
+  })
+    .get('/org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar')
+    .reply(200, 'Success');
+
+  const result = await download(
+    'org.apache.commons:commons-lang3:3.4',
+    tmpDir,
+    'https://private.example.com/maven2/',
+    null,
+    { headers: { Authorization: 'Bearer secret-token' } }
+  );
+  assert.equal(result, path.join(tmpDir, 'commons-lang3-3.4.jar'));
+  assert.equal(fs.readFileSync(result, 'utf8'), 'Success');
+});
+
+test('should abort when fetchOptions.signal is aborted', async () => {
+  await assert.rejects(
+    download('org.apache.commons:commons-lang3:3.4', tmpDir, null, null, {
+      signal: AbortSignal.abort(),
+    }),
+    { name: 'AbortError' }
+  );
+});
+
 test('should error if artifact does not exist', async () => {
   nock('https://repo1.maven.org/maven2/')
     .get('/org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar')

--- a/packages/mvn-artifact-url/src/artifact-url.ts
+++ b/packages/mvn-artifact-url/src/artifact-url.ts
@@ -11,7 +11,7 @@ export interface Artifact {
   snapShotVersion?: string;
 }
 
-export interface FetchOptions {
+export interface FetchOptions extends RequestInit {
   /**
    * request headers, e.g. `{ Authorization: "Bearer ..." }` for private registries
    */


### PR DESCRIPTION
The code was already moved from node-fetch to Node's built-in `fetch` in #91, but that migration left a few things behind. This PR finishes it:

## Changes

- **`FetchOptions` now extends `RequestInit`** in both `mvn-artifact-download` and `mvn-artifact-url`. The options object was already passed straight to the global `fetch`, but the type only allowed `headers`, hiding the native replacements for the removed node-fetch options: `signal` (e.g. `AbortSignal.timeout(1000)`) replaces `timeout`, and undici's `dispatcher` replaces `agent` for proxies/custom certs. Zero runtime change.
- **Docs updated**: the `mvn-artifact-download` readme still documented node-fetch-only `fetchOptions` (`timeout`, `agent`) that native fetch silently ignores — including an example passing `{ timout: 1000 }`. It now documents `headers` and `AbortSignal.timeout`.
- **Removed the `as any` cast** on `response.body`, replaced with a properly typed cast via `node:stream/web`.
- **New tests**: forwarding `fetchOptions.headers` to the registry during download, and rejection with `AbortError` when `fetchOptions.signal` is aborted.

`npm run build` and `npm test` (prettier check + all 5 packages) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASuU7JWRJbyGsAraEipqHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASuU7JWRJbyGsAraEipqHA)_